### PR TITLE
解决两个 windows 安装时的 bug

### DIFF
--- a/src/idcos.io/osinstall/cmd/pe-agent/main.go
+++ b/src/idcos.io/osinstall/cmd/pe-agent/main.go
@@ -344,9 +344,9 @@ func installWindows() error {
 }
 
 func copyFirstBoot() error {
-	var dir = "C:/firstboot"
+	var dir = "C:\\firstboot"
 	if !utils.CheckFileIsExist("c:/windows") {
-		dir = "D:/firstboot"
+		dir = "D:\\firstboot"
 	}
 	var cmd = fmt.Sprintf(`xcopy /s /e /y /i Z:\windows\firstboot %s`, dir)
 	utils.Logger.Debug(cmd)

--- a/src/idcos.io/osinstall/cmd/win-agent/main.go
+++ b/src/idcos.io/osinstall/cmd/win-agent/main.go
@@ -45,7 +45,7 @@ var rootPath = "c:/firstboot"
 var scriptFile = path.Join(rootPath, "temp-script.cmd")
 var preInstallScript = path.Join(rootPath, "preInstall.cmd")
 var postInstallScript = path.Join(rootPath, "postInstall.cmd")
-var serverHost = "osinstall" //cloudboot server host
+var serverHost = "osinstall.idcos.com" //cloudboot server host
 
 func run(c *cli.Context) error {
 	// init log


### PR DESCRIPTION
1. 解决安装windows时，释放完 wim 之后，无法正确的 xcopy firstboot 的问题

问题描述：xcopy执行失败，无法复制firstboot导致安装终止，原因是路径分隔符错误，修改为 \ 即可

相关 issue：https://github.com/idcos/osinstall-server/issues/29


2. 解决 firstboot 无法正确执行的问题

问题描述：ping测 osinstall 不过，无法自动配置网络，原因是 dnsmsq 并未解析该域名，修改为 osinstall.idcos.com 即可

相关 issue：https://github.com/idcos/Cloudboot/issues/21